### PR TITLE
fix: use VALUE=DATE for all-day events instead of DATE-TIME

### DIFF
--- a/chronos_mcp/events.py
+++ b/chronos_mcp/events.py
@@ -66,13 +66,6 @@ class EventManager:
             )
 
         try:
-            # Fix all-day event times
-            if all_day:
-                # Ensure start is at midnight
-                start = start.replace(hour=0, minute=0, second=0, microsecond=0)
-                # End should be midnight of the next day (24 hours later)
-                end = start + timedelta(days=1)
-
             # Validate RRULE if provided
             if recurrence_rule:
                 is_valid, error_msg = validate_rrule(recurrence_rule)
@@ -89,8 +82,12 @@ class EventManager:
 
             event.add("uid", event_uid)
             event.add("summary", summary)
-            event.add("dtstart", start)
-            event.add("dtend", end)
+            if all_day:
+                event.add("dtstart", start.date())
+                event.add("dtend", end.date())
+            else:
+                event.add("dtstart", start)
+                event.add("dtend", end)
             event.add("dtstamp", datetime.now(timezone.utc))
 
             if description:
@@ -439,10 +436,16 @@ class EventManager:
                     del existing_event["description"]
 
             if start is not None:
-                existing_event["dtstart"].dt = start
+                if all_day:
+                    existing_event["dtstart"].dt = start.date()
+                else:
+                    existing_event["dtstart"].dt = start
 
             if end is not None:
-                existing_event["dtend"].dt = end
+                if all_day:
+                    existing_event["dtend"].dt = end.date()
+                else:
+                    existing_event["dtend"].dt = end
 
             if location is not None:
                 if location:


### PR DESCRIPTION
## Description

Fixes #12

All-day events were incorrectly created with `DATE-TIME` format (e.g., `DTSTART:20260629T000000Z`) instead of the RFC 5545 `DATE` format (e.g., `DTSTART;VALUE=DATE:20260629`).

This caused calendar clients (Thunderbird, Nextcloud, etc.) to display them as timed events at midnight UTC rather than true all-day events (with the "All day" checkbox checked).

Additionally, the end date was always overwritten to `start + 1 day` in `create_event`, making it impossible to create multi-day all-day events.

## Changes

In `chronos_mcp/events.py`:

1. **Removed** the block that overwrites the end date with `start + timedelta(days=1)`
2. **`create_event`**: when `all_day=True`, pass `start.date()` / `end.date()` to `icalendar` instead of `datetime` objects — this makes `icalendar` generate `VALUE=DATE` properties
3. **`update_event`**: same fix for `dtstart.dt` and `dtend.dt` assignments

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] All 20 existing unit tests pass (`tests/unit/test_events.py`), including `test_create_event_all_day`
- [x] Manually tested with Nextcloud 30 CalDAV server + Thunderbird client: all-day events now display correctly with the "All day" checkbox checked and no start/end times shown

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation (N/A - no doc changes needed)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes