### PR TITLE
docs: fix README documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,15 +238,14 @@ chronos:update_event(
 
 ## Documentation
 
-- [API Reference](docs/api/README.md) - Complete API documentation
+- [Usage](#usage) - Basic tool usage examples
 - [Architecture Guide](docs/ARCHITECTURE.md) - System design and components
 - [RRULE Guide](docs/RRULE_GUIDE.md) - Recurring events documentation
-- [Data Flows](docs/DATA_FLOWS.md) - Request/response patterns
-- [Design Decisions](docs/DESIGN_DECISIONS.md) - Technical choices explained
+- [VTODO/VJOURNAL Guide](docs/VTODO_VJOURNAL_GUIDE.md) - Task and journal entry documentation
 
 ## Known Issues
 
-See [KNOWN_ISSUES.md](KNOWN_ISSUES.md) for current limitations and workarounds.
+See [GitHub Issues](https://github.com/democratize-technology/chronos-mcp/issues) for current limitations and workarounds.
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
- Replaces the broken README API Reference link with the existing Usage section.
- Removes stale documentation entries that pointed to files not present in the repository.
- Points Known Issues to the repository issue tracker instead of a missing local file.

## Validation
- Passed: README relative file link check; all relative README links now resolve locally.
- Passed: `git diff --check`.
- Passed: `Invoke-WebRequest -Method Head https://github.com/democratize-technology/chronos-mcp/issues` returned HTTP 200.
- Not run: `python -m pytest tests/unit/ -q` because local Python environment does not have `pytest` installed (`No module named pytest`). This is a README-only documentation change.

## Notes
- Closes #24.
- No runtime behavior or compatibility impact expected.
- No follow-up work required for this README link cleanup.