### PR TITLE
fix: emit RELTYPE=PARENT on VTODO RELATED-TO links

### DIFF
--- a/chronos_mcp/tasks.py
+++ b/chronos_mcp/tasks.py
@@ -79,8 +79,13 @@ class TaskManager:
             task.add("percent-complete", 0)
 
             if related_to:
+                # Emit a typed, one-directional parent link. VTODO hierarchy is
+                # expressed as RELTYPE=PARENT on the child only; the referenced
+                # UID is the child's parent. Without RELTYPE some clients (e.g.
+                # jtx Board) treat the link as bidirectional and show the child
+                # as both a subtask and a parent of the list.
                 for related_uid in related_to:
-                    task.add("related-to", related_uid)
+                    task.add("related-to", related_uid, parameters={"RELTYPE": "PARENT"})
 
             cal.add_component(task)
 
@@ -335,10 +340,14 @@ class TaskManager:
                 if "RELATED-TO" in existing_task:
                     del existing_task["RELATED-TO"]
 
-                # Add new RELATED-TO properties if provided
+                # Add new RELATED-TO properties if provided. Typed as
+                # RELTYPE=PARENT so the link stays one-directional (see
+                # create_task for rationale).
                 if related_to:
                     for related_uid in related_to:
-                        existing_task.add("RELATED-TO", related_uid)
+                        existing_task.add(
+                            "RELATED-TO", related_uid, parameters={"RELTYPE": "PARENT"}
+                        )
 
             # Update last-modified timestamp
             if "LAST-MODIFIED" in existing_task:

--- a/tests/unit/test_journals.py
+++ b/tests/unit/test_journals.py
@@ -109,6 +109,24 @@ class TestJournalCRUD:
         assert result.description == "Today was productive"
         mock_calendar.save_journal.assert_called_once()
 
+    def test_create_journal_related_to_stays_untyped(
+        self, journal_manager, mock_calendar, sample_journal_data
+    ):
+        """Journals are not hierarchies: their RELATED-TO must stay untyped.
+
+        Guards against the VTODO RELTYPE=PARENT fix accidentally being applied
+        to journals as well.
+        """
+        journal_manager.calendars.get_calendar.return_value = mock_calendar
+        mock_calendar.save_journal.return_value = Mock()
+
+        with patch("uuid.uuid4", return_value="test-uid-123"):
+            journal_manager.create_journal(**sample_journal_data)
+
+        ical_data = mock_calendar.save_journal.call_args[0][0]
+        assert "RELATED-TO:event-456" in ical_data
+        assert "RELTYPE" not in ical_data
+
     def test_create_journal_fallback_to_save_event(
         self, journal_manager, mock_calendar, sample_journal_data
     ):

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -174,6 +174,40 @@ class TestTaskManager:
         assert result.related_to == sample_task_data["related_to"]
 
     @patch("chronos_mcp.tasks.uuid.uuid4")
+    def test_create_task_related_to_emits_reltype_parent(
+        self, mock_uuid, mock_calendar_manager, mock_calendar
+    ):
+        """RELATED-TO on a subtask must be a typed, one-directional PARENT link.
+
+        Regression test: an untyped RELATED-TO is treated as bidirectional by
+        some clients (e.g. jtx Board), making the child appear as both a subtask
+        and a parent. The child must declare RELTYPE=PARENT and nothing must be
+        written to a second component (no reverse link on the parent).
+        """
+        mock_uuid.return_value = Mock()
+        mock_uuid.return_value.__str__ = Mock(return_value="child-task-123")
+
+        mgr = TaskManager(mock_calendar_manager)
+        mock_calendar_manager.get_calendar.return_value = mock_calendar
+        mock_calendar.save_todo.return_value = Mock()
+
+        mgr.create_task(
+            calendar_uid="cal-123",
+            summary="Child Task",
+            related_to=["parent-task-uid"],
+        )
+
+        # Exactly one save, to the single (child) component — no parent mutation.
+        mock_calendar.save_todo.assert_called_once()
+        mock_calendar.save_event.assert_not_called()
+
+        ical_data = mock_calendar.save_todo.call_args[0][0]
+        assert ical_data.count("RELATED-TO") == 1
+        assert "RELATED-TO;RELTYPE=PARENT:parent-task-uid" in ical_data
+        # No untyped RELATED-TO line.
+        assert "RELATED-TO:parent-task-uid" not in ical_data
+
+    @patch("chronos_mcp.tasks.uuid.uuid4")
     def test_create_task_fallback_to_save_event(
         self, mock_uuid, mock_calendar_manager, mock_calendar
     ):
@@ -311,6 +345,29 @@ class TestTaskManager:
         # Verify
         assert result is not None
         mock_caldav_task.save.assert_called_once()
+
+    def test_update_task_related_to_emits_reltype_parent(
+        self, mock_calendar_manager, mock_calendar, mock_caldav_task
+    ):
+        """update_task must also write RELATED-TO as a typed PARENT link."""
+        mgr = TaskManager(mock_calendar_manager)
+        mock_calendar_manager.get_calendar.return_value = mock_calendar
+        mock_calendar.event_by_uid.return_value = mock_caldav_task
+
+        result = mgr.update_task(
+            task_uid="test-task-123",
+            calendar_uid="cal-123",
+            related_to=["parent-task-uid"],
+        )
+
+        assert result is not None
+        mock_caldav_task.save.assert_called_once()
+
+        # The serialized payload that was saved back to the server.
+        saved_ical = mock_caldav_task.data
+        assert saved_ical.count("RELATED-TO") == 1
+        assert "RELATED-TO;RELTYPE=PARENT:parent-task-uid" in saved_ical
+        assert "RELATED-TO:parent-task-uid" not in saved_ical
 
     def test_delete_task_success_event_by_uid(
         self, mock_calendar_manager, mock_calendar, mock_caldav_task


### PR DESCRIPTION
> 🤖 **AI-generated contribution.** This pull request — code, tests, and description — was written by **Claude** (Anthropic — Claude Code, model Opus 4.8) at the request of the repo owner, and reviewed before submission. The commit also carries a `Co-Authored-By: Claude` trailer.


## Description

Subtask parent links were written as an **untyped** `RELATED-TO` on the child
VTODO. Per RFC 5545 the default `RELTYPE` is `PARENT`, but several CalDAV
clients treat an untyped `RELATED-TO` as bidirectional. In jtx Board, for
example, a task created with `related_to=[parent_uid]` shows up as **both** a
subtask of its parent **and** a duplicate top-level entry.

This change makes `create_task` and `update_task` emit
`RELATED-TO;RELTYPE=PARENT:<uid>` on the child only, so the relationship is
explicit and one-directional. The reciprocal `RELTYPE=CHILD` link — when a
server adds one — remains the server's responsibility; the client does not write
to the referenced parent. Journals (non-hierarchical) and events are
intentionally left untyped.

Fixes the parent/child subtask relationship being written incorrectly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit tests pass (`pytest tests/unit/`)
- [x] Manual testing with a real CalDAV server

New unit tests assert that the child carries exactly one
`RELATED-TO;RELTYPE=PARENT` (no untyped line, no mutation of a second
component), and a guard test confirms journal `RELATED-TO` stays untyped.

Verified end-to-end against Infomaniak CalDAV (`sync.infomaniak.com`): the child
VTODO is stored as `RELATED-TO;RELTYPE=PARENT:<parent>`, the server adds the
typed `RELTYPE=CHILD` reciprocal on the parent, and jtx Board (Android) renders
the subtask correctly with no top-level duplicate.

**Test Configuration**:
* Python version: 3.13
* CalDAV server type and version: Infomaniak (sync.infomaniak.com)
* Operating System: Linux

## Checklist:

- [x] My code follows the style guidelines of this project (black, isort, flake8)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

## Security Checklist:

- [x] No credentials or sensitive data in code or logs
- [x] Error messages sanitized (no stack traces to users)
- [x] No new dependencies with known vulnerabilities

## Additional Notes

Scope is intentionally minimal (VTODO only). Per CONTRIBUTING.md the version
bump is left to the maintainers' release process; happy to add one if preferred.

## Attribution

This change was authored by **Claude** (Anthropic's Claude Code, Opus 4.8). It is AI-written and was human-reviewed before opening this PR. Please review accordingly.